### PR TITLE
Typo fix in package.json (change ^ to >)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sitemap.xml"
   ],
   "dependencies": {
-    "phantomjs": "^1.7.1",
+    "phantomjs": ">1.7.1",
     "xml2js": "~0.2.7",
     "async": "~0.2.10",
     "underscore": "~1.6.0",
@@ -58,6 +58,6 @@
     }
   ],
   "engines": {
-    "node": "^0.10.0"
+    "node": ">0.10.0"
   }
 }


### PR DESCRIPTION
The package.json file for html-snapshots is causing problems when I try to install other npm packages that depend on phantomjs. Looking at the package.json file in this repo, I see the line

```
"dependencies": {
  "phantomjs": "^1.7.1",
...
```

The **^** character doesn't mean anything in a package.json file.

If the package depends on a phantomjs version greater than 1.7.1, what we need is

```
"dependencies": {
  "phantomjs": ">1.7.1",
...
```

Per version range notation in https://www.npmjs.org/doc/json.html#dependencies
